### PR TITLE
Use browserify v13.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function derbyBundler(app, options) {
       bundle.require(derbyPath, {expose: 'derby'});
       // Hack to inject the views script into the Browserify bundle by replacing
       // the empty _views.js file with the generated source
-      const viewsFilename = require.resolve('./_views');
+      const viewsFilename = require.resolve('derby/lib/_views');
       bundle.transform(function(filename) {
         if (filename !== viewsFilename) return through();
         return through(

--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ module.exports = function derbyBundler(app, options) {
     this.emit('bundle', b);
     b.add(file);
     if (process.env.BUNDLE_DEBUG) {
-      b.on('file', (...args) => { console.log('FILE', ...args) });
+      b.pipeline.on('file', (file, id, parent) => {
+        console.log('FILE', file, id, JSON.stringify(parent));
+      });
     }
 
     var bundleStream = (minify) ?

--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ module.exports = function derbyBundler(app, options) {
     var b = browserify(options);
     this.emit('bundle', b);
     b.add(file);
+    if (process.env.BUNDLE_DEBUG) {
+      b.on('file', (...args) => { console.log('FILE', ...args) });
+    }
 
     var bundleStream = (minify) ?
       b.plugin('common-shakeify')

--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = function derbyBundler(app, options) {
 
     var bundleStream = (minify) ?
       b.plugin('common-shakeify')
-        .plugin('browser-pack-flat/plugin')
         .bundle()
         .pipe(minifyStream()) :
       b.bundle();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "Craig Beck <craig.beck@lever.co>",
   "license": "ISC",
   "dependencies": {
-    "browser-pack-flat": "^3.5.0",
     "browserify": "^13.3.0",
     "buffer": "^6.0.3",
     "common-shakeify": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "browser-pack-flat": "^3.5.0",
-    "browserify": "^16.5.2",
+    "browserify": "^13.3.0",
     "buffer": "^6.0.3",
     "common-shakeify": "^1.1.2",
     "exorcist": "^2.0.0",


### PR DESCRIPTION
- Revert to `browserify` version as used in Lever production builds
- Use views stub from `derby` path
- Add `BUNDLE_DEBUG` flag to aid in debugging